### PR TITLE
Release @objectel/operators version 0.1.1

### DIFF
--- a/packages/operators/package-lock.json
+++ b/packages/operators/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@objectel/operators",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/operators/package.json
+++ b/packages/operators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectel/operators",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "provides operators for objectel",
   "index": "index.js",
   "main": "build/lib/operators.js",

--- a/packages/operators/src/toOutputOperator.js
+++ b/packages/operators/src/toOutputOperator.js
@@ -5,6 +5,6 @@ export default function toOutputOperator(component) {
     const children = Array.isArray(props.children) ? props.children : [];
     const input$ = merge(...children.map(element => element(childrenInput$)));
 
-    return component(input$);
+    return component(props)(input$);
   };
 };


### PR DESCRIPTION
Bugfix version of @objectel/operators.

Fixed bug:

1. `toOutputOperator` didn't activate given component.